### PR TITLE
Fix product lookup and dropdown loading

### DIFF
--- a/app/category/[slug]/page.jsx
+++ b/app/category/[slug]/page.jsx
@@ -4,12 +4,14 @@ import { getBaseUrl } from '@/lib/baseUrl';
 
 async function getData(slug) {
   const baseUrl = getBaseUrl();
-  const resCat = await fetch(`${baseUrl}/api/categories?slug=${slug}`, { cache: 'no-store' });
-  const category = await resCat.json();
+  const resCat = await fetch(
+    `${baseUrl}/api/categories?slug=${encodeURIComponent(slug)}`,
+    { cache: 'no-store' }
+  );
+  const category = resCat.ok && resCat.headers.get('content-type')?.includes('application/json') ? await resCat.json() : null;
   if (!category) return null;
   const resProd = await fetch(`${baseUrl}/api/products?category=${category._id}`, { cache: 'no-store' });
-
-  const products = await resProd.json();
+  const products = resProd.ok && resProd.headers.get('content-type')?.includes('application/json') ? await resProd.json() : [];
   return { category, products };
 }
 

--- a/app/product/[slug]/page.jsx
+++ b/app/product/[slug]/page.jsx
@@ -5,11 +5,19 @@ import { getBaseUrl } from '@/lib/baseUrl';
 
 async function getProduct(slug) {
   const baseUrl = getBaseUrl();
-  const res = await fetch(`${baseUrl}/api/products?slug=${slug}`, {
-    cache: 'no-store',
-  });
-
-  return await res.json();
+  try {
+    const res = await fetch(
+      `${baseUrl}/api/products?slug=${encodeURIComponent(slug)}`,
+      { cache: 'no-store' }
+    );
+    if (!res.headers.get('content-type')?.includes('application/json')) {
+      return null;
+    }
+    return await res.json();
+  } catch (err) {
+    console.error('Failed to fetch product', err);
+    return null;
+  }
 }
 
 export default async function ProductPage({ params }) {

--- a/app/products/page.jsx
+++ b/app/products/page.jsx
@@ -4,9 +4,16 @@ import { getBaseUrl } from '@/lib/baseUrl';
 
 async function getProducts() {
   const baseUrl = getBaseUrl();
-  const res = await fetch(`${baseUrl}/api/products`, { cache: 'no-store' });
-
-  return res.json();
+  try {
+    const res = await fetch(`${baseUrl}/api/products`, { cache: 'no-store' });
+    if (!res.ok || !res.headers.get('content-type')?.includes('application/json')) {
+      return [];
+    }
+    return await res.json();
+  } catch (err) {
+    console.error('Failed to fetch products', err);
+    return [];
+  }
 }
 
 export default async function ProductsPage() {

--- a/components/navbar.jsx
+++ b/components/navbar.jsx
@@ -18,7 +18,7 @@ const outfit = Outfit({
 
 export default function Navbar() {
         const [isMenuOpen, setIsMenuOpen] = useState(false);
-        const [categories, setCategories] = useState([]);
+        const [products, setProducts] = useState([]);
         const pathname = usePathname();
         const navigate = useRouter();
 	// Close mobile menu when changing route
@@ -27,9 +27,9 @@ export default function Navbar() {
         }, [pathname]);
 
         useEffect(() => {
-                fetch('/api/categories')
-                        .then((res) => res.json())
-                        .then(setCategories)
+                fetch('/api/products')
+                        .then((res) => (res.ok ? res.json() : []))
+                        .then(setProducts)
                         .catch(() => {});
         }, []);
 
@@ -72,9 +72,9 @@ export default function Navbar() {
                                                 <button className="text-sm font-medium text-gray-600 hover:text-teal-700">Products</button>
                                                 <div className="absolute left-0 z-50 hidden group-hover:block bg-white shadow rounded mt-2 min-w-40">
                                                         <Link href="/products" className="block px-4 py-2 hover:bg-gray-100">All Products</Link>
-                                                        {categories.map((c) => (
-                                                                <Link key={c._id} href={`/category/${c.slug}`} className="block px-4 py-2 hover:bg-gray-100">
-                                                                        {c.name}
+                                                        {products.map((p) => (
+                                                                <Link key={p._id} href={`/product/${p.slug}`} className="block px-4 py-2 hover:bg-gray-100">
+                                                                        {p.name}
                                                                 </Link>
                                                         ))}
                                                 </div>
@@ -141,11 +141,11 @@ export default function Navbar() {
                                                         <summary className="list-none text-sm font-medium text-gray-600 hover:text-teal-700">Products</summary>
                                                         <div className="pl-4 flex flex-col space-y-2 mt-2">
                                                                 <Link href="/products" className="text-sm text-gray-600 hover:text-teal-700">All Products</Link>
-                                                                {categories.map((c) => (
-                                                                        <Link key={c._id} href={`/category/${c.slug}`} className="text-sm text-gray-600 hover:text-teal-700">
-                                                                                {c.name}
+                                                                  {products.map((p) => (
+                                                                        <Link key={p._id} href={`/product/${p.slug}`} className="text-sm text-gray-600 hover:text-teal-700">
+                                                                                {p.name}
                                                                         </Link>
-                                                                ))}
+                                                                  ))}
                                                         </div>
                                                 </details>
 						{/* <Link


### PR DESCRIPTION
## Summary
- encode slug before fetching categories and products
- handle failed fetch in navbar product dropdown
- fetch product by encoded slug

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bae50c374832e8ac15fa1ce768714