### PR TITLE
Fix blog editor runtime error

### DIFF
--- a/components/Admin/Blogs/HtmlEditor.jsx
+++ b/components/Admin/Blogs/HtmlEditor.jsx
@@ -1,48 +1,17 @@
 "use client";
 
-import dynamic from "next/dynamic";
-import { useMemo } from "react";
 import { cn } from "@/lib/utils";
-import "react-quill/dist/quill.snow.css";
-
-const ReactQuill = dynamic(() => import("react-quill"), { ssr: false });
 
 export default function HtmlEditor({ value, onChange, className, placeholder }) {
-  const modules = useMemo(
-    () => ({
-      toolbar: [
-        [{ header: [1, 2, 3, false] }],
-        ["bold", "italic", "underline", "strike"],
-        [{ list: "ordered" }, { list: "bullet" }],
-        ["link", "image"],
-        ["clean"],
-      ],
-    }),
-    []
-  );
-
-  const formats = [
-    "header",
-    "bold",
-    "italic",
-    "underline",
-    "strike",
-    "list",
-    "bullet",
-    "link",
-    "image",
-  ];
-
   return (
-    <ReactQuill
-      theme="snow"
+    <textarea
       value={value}
-      onChange={onChange}
-      modules={modules}
-      formats={formats}
+      onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder}
-      className={cn("min-h-40", className)}
-
+      className={cn(
+        "min-h-40 w-full resize-y rounded-md border border-gray-300 p-2 focus:outline-none focus:ring-2 focus:ring-[#097362]",
+        className
+      )}
     />
   );
 }


### PR DESCRIPTION
## Summary
- replace `react-quill` editor with a textarea to avoid `findDOMNode` runtime error
