### PR TITLE
Add newsletter subscribers feature

### DIFF
--- a/Models/Subscriber.js
+++ b/Models/Subscriber.js
@@ -1,0 +1,12 @@
+import mongoose from 'mongoose';
+
+const subscriberSchema = new mongoose.Schema(
+  {
+    email: { type: String, required: true, unique: true },
+  },
+  { timestamps: true }
+);
+
+const Subscriber = mongoose.models.Subscriber || mongoose.model('Subscriber', subscriberSchema);
+export default Subscriber;
+

--- a/app/admin/subscribers/page.jsx
+++ b/app/admin/subscribers/page.jsx
@@ -1,0 +1,23 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import jwt from 'jsonwebtoken';
+import SubscriberTable from '@/components/Admin/Subscribers/SubscriberTable.jsx';
+
+const JWT_SECRET = process.env.JWT_SECRET;
+
+export default async function SubscribersPage() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get('token')?.value;
+
+  if (!token) redirect('/admin/login');
+
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET);
+    if (decoded.role !== 'admin') redirect('/admin/login');
+  } catch (err) {
+    redirect('/admin/login');
+  }
+
+  return <SubscriberTable />;
+}
+

--- a/app/api/subscribers/export/route.js
+++ b/app/api/subscribers/export/route.js
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/db';
+import Subscriber from '@/Models/Subscriber';
+import { requireAdmin } from '@/lib/auth';
+
+export async function GET() {
+  if (!requireAdmin()) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+  await dbConnect();
+  const subscribers = await Subscriber.find().sort({ createdAt: -1 });
+  const csv = 'Email,Date\n' + subscribers.map(s => `${s.email},${s.createdAt.toISOString()}`).join('\n');
+  const res = new NextResponse(csv);
+  res.headers.set('Content-Type', 'text/csv');
+  res.headers.set('Content-Disposition', 'attachment; filename="subscribers.csv"');
+  return res;
+}
+

--- a/app/api/subscribers/route.js
+++ b/app/api/subscribers/route.js
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/db';
+import Subscriber from '@/Models/Subscriber';
+import { requireAdmin } from '@/lib/auth';
+
+export async function GET() {
+  if (!requireAdmin()) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+  await dbConnect();
+  const subscribers = await Subscriber.find().sort({ createdAt: -1 });
+  return NextResponse.json(subscribers);
+}
+
+export async function POST(req) {
+  await dbConnect();
+  try {
+    const { email } = await req.json();
+    if (!email) {
+      return NextResponse.json({ message: 'Email is required' }, { status: 400 });
+    }
+    await Subscriber.create({ email });
+    return NextResponse.json({ message: 'Subscribed' }, { status: 201 });
+  } catch (err) {
+    return NextResponse.json({ message: 'Server error', error: err.message }, { status: 500 });
+  }
+}
+

--- a/components/Admin/Subscribers/SubscriberTable.jsx
+++ b/components/Admin/Subscribers/SubscriberTable.jsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { RefreshCw, Download } from "lucide-react";
+import LoadingSpinner from "@/components/Admin/Blogs/LoadingSpinner.jsx";
+
+export default function SubscriberTable() {
+  const [subscribers, setSubscribers] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchSubscribers = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/subscribers");
+      if (res.ok) {
+        const data = await res.json();
+        setSubscribers(data || []);
+      }
+    } catch (err) {
+      console.error("Failed to fetch subscribers", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchSubscribers();
+  }, []);
+
+  const handleDownload = async () => {
+    const res = await fetch("/api/subscribers/export");
+    if (!res.ok) return;
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "subscribers.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold text-gray-900">Subscribers</h1>
+        <div className="flex gap-2">
+          <Button onClick={fetchSubscribers} size="sm">
+            <RefreshCw className="w-4 h-4 mr-2" /> Refresh
+          </Button>
+          <Button onClick={handleDownload} size="sm" variant="secondary">
+            <Download className="w-4 h-4 mr-2" /> Download
+          </Button>
+        </div>
+      </div>
+      <div className="bg-white border rounded-lg overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Email</TableHead>
+              <TableHead>Date</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loading ? (
+              <TableRow>
+                <TableCell colSpan="2">
+                  <LoadingSpinner className="py-4" />
+                </TableCell>
+              </TableRow>
+            ) : subscribers.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan="2" className="text-center p-4">
+                  No subscribers found.
+                </TableCell>
+              </TableRow>
+            ) : (
+              subscribers.map((s) => (
+                <TableRow key={s._id}>
+                  <TableCell>{s.email}</TableCell>
+                  <TableCell>{new Date(s.createdAt).toLocaleString()}</TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}
+

--- a/components/AdminSidebar.jsx
+++ b/components/AdminSidebar.jsx
@@ -11,6 +11,7 @@ const links = [
   { href: '/admin/categories', label: 'Categories' },
   { href: '/admin/blogs', label: 'Blogs' },
   { href: '/admin/contacts', label: 'Contacts' },
+  { href: '/admin/subscribers', label: 'Subscribers' },
 ]
 
 export default function AdminSidebar() {

--- a/components/Projects/Projects.jsx
+++ b/components/Projects/Projects.jsx
@@ -73,24 +73,30 @@ export default function ProjectList() {
 			});
 	}, []);
 
-	const handleSubscribe = async (e) => {
-		e.preventDefault();
-		if (!email) return;
+        const handleSubscribe = async (e) => {
+                e.preventDefault();
+                if (!email) return;
 
-		setIsLoading(true);
-		setShowSuccess(false);
+                setIsLoading(true);
+                setShowSuccess(false);
 
-		try {
-			await new Promise((res) => setTimeout(res, 1500));
-			setShowSuccess(true);
-			setEmail("");
-			setTimeout(() => setShowSuccess(false), 2000);
-		} catch (err) {
-			console.error("Subscription failed:", err);
-		} finally {
-			setIsLoading(false);
-		}
-	};
+                try {
+                        const res = await fetch("/api/subscribers", {
+                                method: "POST",
+                                headers: { "Content-Type": "application/json" },
+                                body: JSON.stringify({ email }),
+                        });
+                        if (res.ok) {
+                                setShowSuccess(true);
+                                setEmail("");
+                                setTimeout(() => setShowSuccess(false), 2000);
+                        }
+                } catch (err) {
+                        console.error("Subscription failed:", err);
+                } finally {
+                        setIsLoading(false);
+                }
+        };
 
 	if (loading) {
 		return (


### PR DESCRIPTION
## Summary
- create `Subscriber` mongoose model
- add API routes to handle subscribing and export to CSV
- implement admin page with table and download option
- update admin sidebar
- connect subscribe form on projects page to backend

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889d5ef0a00832eb9e4710dd947275f