### PR TITLE
Add project management table with edit and delete

### DIFF
--- a/app/api/project/[id]/route.js
+++ b/app/api/project/[id]/route.js
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/db';
+import Project from '@/Models/Project';
+import { requireAdmin } from '@/lib/auth';
+
+export async function GET(req, { params }) {
+  const { id } = await params;
+  await dbConnect();
+  const project = await Project.findById(id);
+  if (!project) return NextResponse.json({ message: 'Not found' }, { status: 404 });
+  return NextResponse.json(project);
+}
+
+export async function PUT(req, { params }) {
+  const { id } = await params;
+  if (!requireAdmin()) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+  await dbConnect();
+  const body = await req.json();
+  const project = await Project.findByIdAndUpdate(id, body, { new: true });
+  if (!project) return NextResponse.json({ message: 'Not found' }, { status: 404 });
+  return NextResponse.json(project);
+}
+
+export async function DELETE(req, { params }) {
+  const { id } = await params;
+  if (!requireAdmin()) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+  }
+  await dbConnect();
+  await Project.findByIdAndDelete(id);
+  return NextResponse.json({ message: 'Deleted' });
+}


### PR DESCRIPTION
## Summary
- allow fetching and updating individual projects via new API routes
- show existing projects in an admin table with edit and delete controls

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890937c47e0832e8b91d58df804d4a6