### PR TITLE
feat: add email otp registration and dynamic product filters

### DIFF
--- a/app/api/dealer/register/route.js
+++ b/app/api/dealer/register/route.js
@@ -1,14 +1,61 @@
 import dbConnect from '@/lib/db';
 import User from '@/Models/User';
 import bcrypt from 'bcrypt';
+import nodemailer from 'nodemailer';
 import { NextResponse } from 'next/server';
+
+// In-memory store for OTPs and pending users
+const pendingUsers = new Map();
 
 export async function POST(req) {
   await dbConnect();
 
   const body = await req.json();
-  const { firstName, lastName, mobile, firmName, gstin, email, password } = body;
+  const {
+    firstName,
+    lastName,
+    mobile,
+    firmName,
+    gstin,
+    email,
+    password,
+    otp,
+  } = body;
 
+  // Step 2: verify OTP and create user
+  if (otp) {
+    const pending = pendingUsers.get(email);
+    if (!pending || pending.otp !== otp || pending.expires < Date.now()) {
+      return NextResponse.json({ message: 'Invalid or expired OTP' }, { status: 400 });
+    }
+
+    const existingUser = await User.findOne({ email });
+    if (existingUser) {
+      pendingUsers.delete(email);
+      return NextResponse.json({ message: 'User already exists' }, { status: 409 });
+    }
+
+    try {
+      const hashedPassword = await bcrypt.hash(pending.password, 10);
+      await User.create({
+        name: `${pending.firstName} ${pending.lastName}`,
+        firstName: pending.firstName,
+        lastName: pending.lastName,
+        mobile: pending.mobile,
+        firmName: pending.firmName,
+        gstin: pending.gstin,
+        email: pending.email,
+        password: hashedPassword,
+        role: 'dealer',
+      });
+      pendingUsers.delete(email);
+      return NextResponse.json({ message: 'User registered successfully' });
+    } catch (err) {
+      return NextResponse.json({ message: 'Server error', error: err.message }, { status: 500 });
+    }
+  }
+
+  // Step 1: collect data and send OTP
   if (!firstName || !lastName || !mobile || !firmName || !gstin || !email || !password) {
     return NextResponse.json({ message: 'All fields are required' }, { status: 400 });
   }
@@ -19,21 +66,38 @@ export async function POST(req) {
       return NextResponse.json({ message: 'User already exists' }, { status: 409 });
     }
 
-    const hashedPassword = await bcrypt.hash(password, 10);
+    const otpCode = Math.floor(100000 + Math.random() * 900000).toString();
 
-    await User.create({
-      name: `${firstName} ${lastName}`,
+    pendingUsers.set(email, {
       firstName,
       lastName,
       mobile,
       firmName,
       gstin,
       email,
-      password: hashedPassword,
-      role: 'dealer',
+      password,
+      otp: otpCode,
+      expires: Date.now() + 10 * 60 * 1000,
     });
 
-    return NextResponse.json({ message: 'User registered successfully' });
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: process.env.SMTP_PORT ? parseInt(process.env.SMTP_PORT) : 587,
+      secure: false,
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    await transporter.sendMail({
+      from: process.env.EMAIL_FROM || process.env.SMTP_USER,
+      to: email,
+      subject: 'Your verification code',
+      text: `Your OTP is ${otpCode}`,
+    });
+
+    return NextResponse.json({ message: 'OTP sent to email' });
   } catch (err) {
     return NextResponse.json({ message: 'Server error', error: err.message }, { status: 500 });
   }

--- a/app/products/page.jsx
+++ b/app/products/page.jsx
@@ -1,5 +1,4 @@
-import ProductFilters from "@/components/PreviousUsedComponent/Solutions/ProductFilters.jsx";
-import ProductGallery from "@/components/Products/ProductGallery.jsx";
+import ProductsClient from "@/components/Products/ProductsClient.jsx";
 
 export const dynamic = "force-dynamic";
 
@@ -21,19 +20,5 @@ async function getProducts() {
 
 export default async function ProductsPage() {
   const products = await getProducts();
-  return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="container mx-auto px-4 py-8">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
-          <aside className="md:col-span-1 md:sticky md:top-24 md:h-[calc(100vh-6rem)] md:overflow-auto">
-            <ProductFilters />
-          </aside>
-          <div className="md:col-span-3">
-            <ProductGallery products={products} />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+  return <ProductsClient products={products} />;
 }
-

--- a/app/register/page.jsx
+++ b/app/register/page.jsx
@@ -17,6 +17,8 @@ export default function RegisterPage() {
     password: '',
     confirmPassword: '',
   });
+  const [otp, setOtp] = useState('');
+  const [otpSent, setOtpSent] = useState(false);
   const [error, setError] = useState('');
   const router = useRouter();
 
@@ -43,7 +45,27 @@ export default function RegisterPage() {
         setError(responseData.message || 'Registration failed');
         return;
       }
-      router.push('/login');
+      setOtpSent(true);
+    } catch (err) {
+      setError('Something went wrong. Please try again.');
+    }
+  };
+
+  const handleVerify = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('/api/dealer/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: formData.email, otp }),
+      });
+      const responseData = await res.json();
+      if (!res.ok) {
+        setError(responseData.message || 'Verification failed');
+        return;
+      }
+      router.push('/products');
     } catch (err) {
       setError('Something went wrong. Please try again.');
     }
@@ -51,46 +73,65 @@ export default function RegisterPage() {
 
   return (
     <div className="min-h-screen flex items-center justify-center px-4">
-      <div className="w-full max-w-md border border-gray-200 rounded-2xl shadow-lg p-6">
-        <h2 className="text-2xl font-semibold text-center mb-6 text-[#097362]">Dealer Registration</h2>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="firstName" className="text-[#097362]">First Name</Label>
-              <Input id="firstName" name="firstName" value={formData.firstName} onChange={handleChange} required />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="lastName" className="text-[#097362]">Last Name</Label>
-              <Input id="lastName" name="lastName" value={formData.lastName} onChange={handleChange} required />
-            </div>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="mobile" className="text-[#097362]">Mobile Number</Label>
-            <Input id="mobile" name="mobile" value={formData.mobile} onChange={handleChange} required />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="firmName" className="text-[#097362]">Firm Name</Label>
-            <Input id="firmName" name="firmName" value={formData.firmName} onChange={handleChange} required />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="gstin" className="text-[#097362]">GSTIN</Label>
-            <Input id="gstin" name="gstin" value={formData.gstin} onChange={handleChange} required />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="email" className="text-[#097362]">Email</Label>
-            <Input id="email" type="email" name="email" value={formData.email} onChange={handleChange} required />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="password" className="text-[#097362]">Password</Label>
-            <Input id="password" type="password" name="password" value={formData.password} onChange={handleChange} required />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="confirmPassword" className="text-[#097362]">Confirm Password</Label>
-            <Input id="confirmPassword" type="password" name="confirmPassword" value={formData.confirmPassword} onChange={handleChange} required />
-          </div>
-          {error && <p className="text-sm text-red-600">{error}</p>}
-          <Button type="submit" className="w-full rounded-full bg-gradient-to-b from-[#097362] to-[#0FA78E] cursor-pointer">Register</Button>
-        </form>
+      <div className="w-full max-w-4xl grid md:grid-cols-2 gap-8">
+        <div className="hidden md:flex flex-col justify-center space-y-4">
+          <h2 className="text-3xl font-bold text-[#097362]">Welcome to Ladwa</h2>
+          <p className="text-gray-600">Register as a dealer to explore our products.</p>
+        </div>
+        <div className="border border-gray-200 rounded-2xl shadow-lg p-6">
+          <h2 className="text-2xl font-semibold text-center mb-6 text-[#097362]">
+            {otpSent ? 'Enter OTP' : 'Dealer Registration'}
+          </h2>
+          {!otpSent ? (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="firstName" className="text-[#097362]">First Name</Label>
+                  <Input id="firstName" name="firstName" value={formData.firstName} onChange={handleChange} required />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="lastName" className="text-[#097362]">Last Name</Label>
+                  <Input id="lastName" name="lastName" value={formData.lastName} onChange={handleChange} required />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="mobile" className="text-[#097362]">Mobile Number</Label>
+                <Input id="mobile" name="mobile" value={formData.mobile} onChange={handleChange} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="firmName" className="text-[#097362]">Firm Name</Label>
+                <Input id="firmName" name="firmName" value={formData.firmName} onChange={handleChange} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="gstin" className="text-[#097362]">GSTIN</Label>
+                <Input id="gstin" name="gstin" value={formData.gstin} onChange={handleChange} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="email" className="text-[#097362]">Email</Label>
+                <Input id="email" type="email" name="email" value={formData.email} onChange={handleChange} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="password" className="text-[#097362]">Password</Label>
+                <Input id="password" type="password" name="password" value={formData.password} onChange={handleChange} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="confirmPassword" className="text-[#097362]">Confirm Password</Label>
+                <Input id="confirmPassword" type="password" name="confirmPassword" value={formData.confirmPassword} onChange={handleChange} required />
+              </div>
+              {error && <p className="text-sm text-red-600">{error}</p>}
+              <Button type="submit" className="w-full rounded-full bg-gradient-to-b from-[#097362] to-[#0FA78E] cursor-pointer">Send OTP</Button>
+            </form>
+          ) : (
+            <form onSubmit={handleVerify} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="otp" className="text-[#097362]">OTP</Label>
+                <Input id="otp" name="otp" value={otp} onChange={(e) => setOtp(e.target.value)} required />
+              </div>
+              {error && <p className="text-sm text-red-600">{error}</p>}
+              <Button type="submit" className="w-full rounded-full bg-gradient-to-b from-[#097362] to-[#0FA78E] cursor-pointer">Verify OTP</Button>
+            </form>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/components/Products/ProductFilters.jsx
+++ b/components/Products/ProductFilters.jsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Slider } from "@/components/ui/slider";
+import { Checkbox } from "@/components/ui/checkbox";
+
+export default function ProductFilters({ products, onChange }) {
+  const categoryMap = new Map();
+  products.forEach((p) => {
+    const id = p.category?._id || p.category;
+    const name = p.category?.name || "Unknown";
+    categoryMap.set(id, name);
+  });
+  const categories = Array.from(categoryMap.entries());
+
+  const prices = products.map((p) => parseFloat(p.yourPriceInr) || 0);
+  const minPrice = Math.min(...prices, 0);
+  const maxPrice = Math.max(...prices, 0);
+
+  const [selectedCategories, setSelectedCategories] = useState([]);
+  const [priceRange, setPriceRange] = useState([minPrice, maxPrice]);
+
+  useEffect(() => {
+    onChange({ categories: selectedCategories, price: priceRange });
+  }, [selectedCategories, priceRange, onChange]);
+
+  const toggleCategory = (id) => {
+    setSelectedCategories((prev) =>
+      prev.includes(id) ? prev.filter((c) => c !== id) : [...prev, id]
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Categories</h2>
+        <div className="space-y-2">
+          {categories.map(([id, name]) => (
+            <div key={id} className="flex items-center space-x-2">
+              <Checkbox
+                id={`cat-${id}`}
+                checked={selectedCategories.includes(id)}
+                onCheckedChange={() => toggleCategory(id)}
+              />
+              <label htmlFor={`cat-${id}`} className="text-sm font-medium">
+                {name}
+              </label>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Price</h2>
+        <Slider
+          value={priceRange}
+          onValueChange={setPriceRange}
+          min={minPrice}
+          max={maxPrice}
+          step={1}
+        />
+        <div className="flex justify-between mt-2 text-sm text-gray-500">
+          <span>₹{priceRange[0]}</span>
+          <span>₹{priceRange[1]}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/Products/ProductsClient.jsx
+++ b/components/Products/ProductsClient.jsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import ProductFilters from "./ProductFilters";
+import ProductGallery from "./ProductGallery";
+
+export default function ProductsClient({ products }) {
+  const prices = products.map((p) => parseFloat(p.yourPriceInr) || 0);
+  const minPrice = Math.min(...prices, 0);
+  const maxPrice = Math.max(...prices, 0);
+  const [filters, setFilters] = useState({ categories: [], price: [minPrice, maxPrice] });
+
+  const filtered = useMemo(() => {
+    return products.filter((p) => {
+      const price = parseFloat(p.yourPriceInr) || 0;
+      const inCategory =
+        filters.categories.length === 0 ||
+        filters.categories.includes(p.category?._id || p.category);
+      const inPrice = price >= filters.price[0] && price <= filters.price[1];
+      return inCategory && inPrice;
+    });
+  }, [products, filters]);
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="container mx-auto px-4 py-8">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
+          <aside className="md:col-span-1 md:sticky md:top-24 md:h-[calc(100vh-6rem)] md:overflow-auto">
+            <ProductFilters products={products} onChange={setFilters} />
+          </aside>
+          <div className="md:col-span-3">
+            <ProductGallery products={filtered} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add OTP-based dealer registration flow with email verification
- redesign registration page with OTP step and welcome panel
- implement client-side product filtering by category and price

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b4299e7d4832eb6eafc5ab5259527