### PR TITLE
refactor: standardize Cloudinary uploads

### DIFF
--- a/app/admin/categories/CategoryForm.jsx
+++ b/app/admin/categories/CategoryForm.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { uploadImage } from '@/lib/upload';
 
 export default function CategoryForm() {
   const [categories, setCategories] = useState([]);
@@ -49,15 +50,12 @@ export default function CategoryForm() {
   const handleImageUpload = async (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    const fd = new FormData();
-    fd.append('file', file);
     setUploading(true);
     try {
-      const res = await fetch('/api/upload', { method: 'POST', body: fd });
-      const data = await res.json();
-      if (data.url) {
-        setForm({ ...form, image: data.url });
-      }
+      const url = await uploadImage(file);
+      setForm({ ...form, image: url });
+    } catch (err) {
+      console.error(err);
     } finally {
       setUploading(false);
     }

--- a/app/admin/list-products/page.jsx
+++ b/app/admin/list-products/page.jsx
@@ -16,6 +16,7 @@ import { Dialog, DialogContent, DialogHeader } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
+import { uploadImage } from "@/lib/upload";
 import {
   Pagination,
   PaginationContent,
@@ -198,20 +199,14 @@ export default function ProductTable() {
     });
   };
 
-  const uploadFile = async (file) => {
-    const fd = new FormData();
-    fd.append("file", file);
-    const res = await fetch("/api/upload", { method: "POST", body: fd });
-    const data = await res.json();
-    return data.url;
-  };
+  // Image uploads handled via shared utility
 
   const handleImageUpload = async (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
     setUploading(true);
     try {
-      const url = await uploadFile(file);
+      const url = await uploadImage(file);
       if (url) setForm({ ...form, image: url });
     } finally {
       setUploading(false);
@@ -499,7 +494,7 @@ export default function ProductTable() {
                   try {
                     const urls = [];
                     for (const file of files) {
-                      const url = await uploadFile(file);
+                      const url = await uploadImage(file);
                       if (url) urls.push(url);
                     }
                     setForm((prev) => ({

--- a/app/admin/products/ProductForm.jsx
+++ b/app/admin/products/ProductForm.jsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { uploadImage } from '@/lib/upload';
 
 const singleFields = [
   { name: 'productType', label: 'Product Type' },
@@ -246,20 +247,14 @@ export default function ProductForm() {
     fetchData();
   };
 
-  const uploadFile = async (file) => {
-    const fd = new FormData();
-    fd.append('file', file);
-    const res = await fetch('/api/upload', { method: 'POST', body: fd });
-    const data = await res.json();
-    return data.url;
-  };
+  // Image uploads handled via shared utility
 
   const handleImageUpload = async (e) => {
     const file = e.target.files?.[0];
     if (!file) return;
     setUploading(true);
     try {
-      const url = await uploadFile(file);
+      const url = await uploadImage(file);
       if (url) setForm({ ...form, image: url });
     } finally {
       setUploading(false);
@@ -273,7 +268,7 @@ export default function ProductForm() {
     try {
       const uploaded = [];
       for (const f of files) {
-        const url = await uploadFile(f);
+        const url = await uploadImage(f);
         if (url) uploaded.push(url);
       }
       setForm({ ...form, gallery: uploaded.join('\n') });

--- a/app/admin/projects/ProjectForm.jsx
+++ b/app/admin/projects/ProjectForm.jsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { uploadImage } from '@/lib/upload';
 
 const ProjectForm = () => {
   const [formData, setFormData] = useState({
@@ -35,43 +36,7 @@ const ProjectForm = () => {
     fetchProjects();
   }, []);
 
-  const uploadFile = async (file) => {
-    const fd = new FormData();
-    fd.append('file', file);
-
-    let res;
-    try {
-      res = await fetch('/api/upload', { method: 'POST', body: fd });
-    } catch (err) {
-      console.error('Network error during upload:', err);
-      throw new Error('Network error during upload');
-    }
-
-    if (!res.ok) {
-      let message = 'Upload failed';
-      try {
-        const errData = await res.json();
-        message =
-          [errData.error || errData.message, errData.details]
-            .filter(Boolean)
-            .join(': ') || message;
-      } catch {
-        const text = await res.text();
-        message = text || message;
-      }
-      console.error('Upload API responded with error:', message);
-      throw new Error(message);
-    }
-
-    try {
-      const data = await res.json();
-      if (!data.url) throw new Error('Upload failed');
-      return data.url;
-    } catch (err) {
-      console.error('Failed to parse upload response:', err);
-      throw new Error(err.message || 'Invalid server response');
-    }
-  };
+  // Image upload is handled by shared utility in @/lib/upload
 
   const handleMainImageChange = async (e) => {
     const file = e.target.files[0];
@@ -79,7 +44,7 @@ const ProjectForm = () => {
     if (/\.(jpe?g|png)$/i.test(file.name)) {
       setUploading(true);
       try {
-        const url = await uploadFile(file);
+        const url = await uploadImage(file);
         setFormData((prev) => ({ ...prev, mainImage: url }));
         setMainImagePreview(url);
       } catch (err) {
@@ -118,7 +83,7 @@ const ProjectForm = () => {
     try {
       const uploaded = [];
       for (const f of allowedFiles) {
-        const url = await uploadFile(f);
+        const url = await uploadImage(f);
         uploaded.push(url);
       }
 

--- a/app/api/upload/route.js
+++ b/app/api/upload/route.js
@@ -39,6 +39,23 @@ export async function POST(req) {
       return NextResponse.json({ error: 'No file provided' }, { status: 400 });
     }
 
+    if (!file.type?.startsWith('image/')) {
+      console.error('Invalid file type:', file.type);
+      return NextResponse.json({ error: 'Only image uploads are allowed' }, { status: 400 });
+    }
+
+    const allowed = ['image/jpeg', 'image/png', 'image/webp'];
+    if (!allowed.includes(file.type)) {
+      console.error('Unsupported image type:', file.type);
+      return NextResponse.json({ error: 'Unsupported image type' }, { status: 400 });
+    }
+
+    const maxSize = 5 * 1024 * 1024; // 5MB
+    if (file.size > maxSize) {
+      console.error('File too large:', file.size);
+      return NextResponse.json({ error: 'File too large' }, { status: 400 });
+    }
+
     console.log('Uploading file to Cloudinary:', file.name || 'unknown');
 
     const arrayBuffer = await file.arrayBuffer();

--- a/components/Admin/Blogs/BlogForm.jsx
+++ b/components/Admin/Blogs/BlogForm.jsx
@@ -10,6 +10,7 @@ import HtmlEditor from "@/components/Admin/Blogs/HtmlEditor.jsx";
 import { X, Save } from "lucide-react";
 import LoadingSpinner from "@/components/Admin/Blogs/LoadingSpinner.jsx";
 import RichTextEditor from "@/components/Admin/Blogs/DynamicRichTextEditor.jsx";
+import { uploadImage } from "@/lib/upload";
 
 const categories = [
 	"Safety Equipment",
@@ -75,13 +76,7 @@ export default function BlogForm({ blog = null, onClose, onSave }) {
 		}));
 	};
 
-	const uploadFile = async (file) => {
-		const fd = new FormData();
-		fd.append("file", file);
-		const res = await fetch("/api/upload", { method: "POST", body: fd });
-		const data = await res.json();
-		return data.url;
-	};
+        // Image upload handled by shared utility
 
 	const handleImageUpload = async (e) => {
 		const file = e.target.files?.[0];
@@ -89,7 +84,7 @@ export default function BlogForm({ blog = null, onClose, onSave }) {
 
 		setUploading(true);
 		try {
-			const url = await uploadFile(file);
+                        const url = await uploadImage(file);
 			if (url) setForm((prev) => ({ ...prev, featuredImage: url }));
 		} catch (error) {
 			console.error("Upload failed:", error);

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -1,0 +1,35 @@
+export async function uploadImage(file) {
+  const fd = new FormData();
+  fd.append('file', file);
+
+  let res;
+  try {
+    res = await fetch('/api/upload', { method: 'POST', body: fd });
+  } catch (err) {
+    console.error('Network error during upload:', err);
+    throw new Error('Network error during upload');
+  }
+
+  if (!res.ok) {
+    let message = 'Upload failed';
+    try {
+      const errData = await res.json();
+      message = [errData.error || errData.message, errData.details]
+        .filter(Boolean)
+        .join(': ') || message;
+    } catch {
+      const text = await res.text();
+      message = text || message;
+    }
+    throw new Error(message);
+  }
+
+  try {
+    const data = await res.json();
+    if (!data.url) throw new Error('Upload failed');
+    return data.url;
+  } catch (err) {
+    console.error('Failed to parse upload response:', err);
+    throw new Error(err.message || 'Invalid server response');
+  }
+}


### PR DESCRIPTION
## Summary
- centralize Cloudinary uploads with shared `uploadImage` helper
- validate image type and size in `/api/upload` API
- refactor admin forms to use shared upload utility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be9b9c6034832ebdb1833eee139dd7