### PR TITLE
Fix missing CloudinaryWidget import on product list page

### DIFF
--- a/app/admin/list-products/page.jsx
+++ b/app/admin/list-products/page.jsx
@@ -17,6 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { uploadImage } from "@/lib/upload";
+import CloudinaryWidget from "@/components/CloudinaryWidget";
 import {
   Pagination,
   PaginationContent,
@@ -198,18 +199,10 @@ export default function ProductTable() {
     });
   };
 
-  // Image uploads handled via shared utility
-
-  const handleImageUpload = async (e) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setUploading(true);
-    try {
-      const url = await uploadImage(file);
-      if (url) setForm({ ...form, image: url });
-    } finally {
-      setUploading(false);
-    }
+  // Image upload handler for Cloudinary widget
+  const handleImageUpload = (url) => {
+    if (!url) return;
+    setForm({ ...form, image: url });
   };
 
   const handleUpdate = async () => {


### PR DESCRIPTION
## Summary
- Import CloudinaryWidget and update image handler on admin product list page to support Cloudinary uploads

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68beabd308dc832ebde3032780ed2bdf