### PR TITLE
fix: define uploading state for admin list-products page

### DIFF
--- a/app/admin/list-products/page.jsx
+++ b/app/admin/list-products/page.jsx
@@ -93,6 +93,7 @@ export default function ProductTable() {
   const [form, setForm] = useState({});
   const [search, setSearch] = useState("");
   const [searchDebounced, setSearchDebounced] = useState("");
+  const [uploading, setUploading] = useState(false);
 
   useEffect(() => {
     const timer = setTimeout(() => {


### PR DESCRIPTION
## Summary
- define `uploading` state to track gallery uploads
